### PR TITLE
PaloAlto VM nics order fix

### DIFF
--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -506,16 +506,16 @@
 				},
 				"networkProfile": {
 					"networkInterfaces": [
-						{              
-							"id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('vmNamePrefix'), copyindex(1), '-',variables('untrustedNicNamePrefix')))]",
-							"properties": {
-								"primary": true
-							}
-						},
 						{
 							"id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('vmNamePrefix'), copyindex(1), '-',variables('managementNicNamePrefix')))]",
 							"properties": {
 								"primary": false
+							}
+						},
+						{              
+							"id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('vmNamePrefix'), copyindex(1), '-',variables('untrustedNicNamePrefix')))]",
+							"properties": {
+								"primary": true
 							}
 						},
 						{


### PR DESCRIPTION
Palo Alto require that the management interface has to be eth0, therefore in creation of the VM you need make sure the NIC for management is created first.